### PR TITLE
Pin D3 version to 3.4.3

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -16,7 +16,7 @@
 {% if current == '/' %}
 <link rel="stylesheet" href="/visualisation/p2p.css" type="text/css">
 
-<script src="http://d3js.org/d3.v3.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/d3/3.4.3/d3.min.js"></script>
 <script src="/visualisation/queue.js"></script>
 <script src="/visualisation/underscore-min.js"></script>
 


### PR DESCRIPTION
It seems that 3.4.4 introduced a breaking change. I know not what, because D3 is witchcraft.
